### PR TITLE
fix: revert header to older version while preserving theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -15,10 +15,7 @@
     <div class="container">
         <header>
             <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
+                <h1>Course Materials Assistant</h1>
                 <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme" title="Toggle light/dark theme">
                     <svg class="sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="5"></circle>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -150,10 +150,6 @@ header {
     margin: 0 auto;
 }
 
-.header-text {
-    flex: 1;
-}
-
 header h1 {
     font-size: 1.75rem;
     font-weight: 700;
@@ -162,12 +158,7 @@ header h1 {
     -webkit-text-fill-color: transparent;
     background-clip: text;
     margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
+    flex: 1;
 }
 
 /* Theme Toggle Button */
@@ -995,13 +986,8 @@ details[open] .chat-history-header::before {
         gap: 1rem;
     }
     
-    .header-text h1 {
+    header h1 {
         font-size: 1.25rem;
-    }
-    
-    .header-text .subtitle {
-        font-size: 0.85rem;
-        margin-top: 0.25rem;
     }
     
     .theme-toggle {


### PR DESCRIPTION
Fixes #2

Reverted the header to the older, simpler version as requested while preserving the theme toggle functionality.

## Changes
- Removed subtitle from header
- Simplified HTML structure
- Updated CSS to remove unused styles
- Preserved theme toggle button functionality

Generated with [Claude Code](https://claude.ai/code)